### PR TITLE
Add range parameter support to tamesgen

### DIFF
--- a/tamesgen.cpp
+++ b/tamesgen.cpp
@@ -3,20 +3,46 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "utils.h"
 
 #define DB_REC_LEN 32
 
 int main(int argc, char* argv[])
 {
-        if (argc < 3)
+        int range = 0;
+        int ci = 1;
+        while (ci < argc && argv[ci][0] == '-')
         {
-                printf("Usage: %s <output_file> <count>\n", argv[0]);
+                char* argument = argv[ci];
+                ci++;
+                if (strcmp(argument, "-range") == 0)
+                {
+                        if (ci >= argc)
+                        {
+                                printf("Usage: %s -range <bits(32-170)> <output_file> <count>\n", argv[0]);
+                                return 1;
+                        }
+                        range = atoi(argv[ci]);
+                        ci++;
+                }
+                else
+                {
+                        printf("Usage: %s -range <bits(32-170)> <output_file> <count>\n", argv[0]);
+                        return 1;
+                }
+        }
+
+        if ((range < 32) || (range > 170) || (argc - ci < 2))
+        {
+                printf("Usage: %s -range <bits(32-170)> <output_file> <count>\n", argv[0]);
                 return 1;
         }
 
-        int count = atoi(argv[2]);
+        char* out_file = argv[ci];
+        int count = atoi(argv[ci + 1]);
         TFastBase* db = new TFastBase();
+        db->Header[0] = range;
 
         for (int i = 0; i < count; i++)
         {
@@ -26,9 +52,9 @@ int main(int argc, char* argv[])
                 db->AddDataBlock(data);
         }
 
-        if (db->SaveToFileBase128(argv[1]))
+        if (db->SaveToFileBase128(out_file))
         {
-                printf("Generated %d tames to %s\n", count, argv[1]);
+                printf("Generated %d tames to %s\n", count, out_file);
                 delete db;
                 return 0;
         }


### PR DESCRIPTION
## Summary
- allow tamesgen to parse a required `-range <bits>` option with validation against 32–170
- embed the keyspace width in generated files via `db->Header[0]`
- clarify usage message for invalid or missing `-range`

## Testing
- `make tamesgen`
- `./tamesgen` (usage)
- `./tamesgen -range 10 file.dat 5` (invalid range)
- `./tamesgen -range 80 mytames.dat 5`
- `./checkheader mytames.dat`
- `make rckangaroo` *(fails: cuda_runtime.h: No such file or directory)*
- `apt-get update`
- `apt-get install -y nvidia-cuda-toolkit` *(fails: ca-certificates-java post-installation error)*

------
https://chatgpt.com/codex/tasks/task_e_689d399fea28832e9e1ee157ac49c868