### PR TITLE
Add Base128 fallback for tames loading

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -351,7 +351,16 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
         if (!gGenMode && gTamesFileName[0])
         {
                 printf("load tames...\r\n");
-                bool ok = gTamesBase128 ? db.LoadFromFileBase128(gTamesFileName) : db.LoadFromFile(gTamesFileName);
+                bool ok = db.LoadFromFile(gTamesFileName);
+                if (!ok)
+                {
+                        printf("binary tames loading failed, trying Base128...\r\n");
+                        ok = db.LoadFromFileBase128(gTamesFileName);
+                        if (ok)
+                                gTamesBase128 = true;
+                }
+                else
+                        gTamesBase128 = false;
                 if (ok)
                 {
                         printf("tames loaded\r\n");
@@ -575,13 +584,6 @@ bool ParseCommandLine(int argc, char* argv[])
 			ci++;
 		}
 		else
-                if (strcmp(argument, "-tames128") == 0)
-                {
-                        gTamesBase128 = true;
-                        strcpy(gTamesFileName, argv[ci]);
-                        ci++;
-                }
-                else
                 if (strcmp(argument, "-tames") == 0)
                 {
                         strcpy(gTamesFileName, argv[ci]);
@@ -648,12 +650,13 @@ int main(int argc, char* argv[])
 
 	InitEc();
 	gDP = 0;
-	gRange = 0;
-	gStartSet = false;
-	gTamesFileName[0] = 0;
-	gMax = 0.0;
-	gGenMode = false;
-	gIsOpsLimit = false;
+        gRange = 0;
+        gStartSet = false;
+        gTamesFileName[0] = 0;
+        gTamesBase128 = false;
+        gMax = 0.0;
+        gGenMode = false;
+        gIsOpsLimit = false;
 	memset(gGPUs_Mask, 1, sizeof(gGPUs_Mask));
 	if (!ParseCommandLine(argc, argv))
 		return 0;

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Discussion thread: https://bitcointalk.org/index.php?topic=5517607
 
 <b>-max</b>		option to limit max number of operations. For example, value 5.5 limits number of operations to 5.5 * 1.15 * sqrt(range), software stops when the limit is reached. 
 
-<b>-tames</b>		filename with tames. If file not found, software generates tames (option "-max" is required) and saves them to the file. If the file is found, software loads tames to speedup solving. 
-<b>-tames128</b>        same as -tames but expects the file to be in base128 format.
+<b>-tames</b>		filename with tames. If file not found, software generates tames (option "-max" is required) and saves them to the file. If the file is found, software loads tames to speedup solving. The program first attempts to load a binary file and automatically falls back to Base128 if needed. 
 
 When public key is solved, software displays it and also writes it to "RESULTS.TXT" file. 
 


### PR DESCRIPTION
## Summary
- Remove dedicated `-tames128` flag and handle all tames via `-tames`
- Retry Base128 loading if binary tames file load fails and report fallback
- Document new Base128 fallback behavior in README

## Testing
- `make rckangaroo` *(fails: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d4d46d114832e8639b414deb10d03