### PR TITLE
Use 64-bit count in tames generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ RCKangaroo.exe -dp 16 -range 84 -start 1000000000000000000000 -pubkey 0329c4574a
 Sample command to generate tames:
 
 RCKangaroo.exe -dp 16 -range 76 -tames tames76.dat -max 10
-You can also quickly generate a base128 tames file using the helper tool:
+You can also quickly generate a base128 tames file using the helper tool (count parameter supports 64-bit values):
 
-./tamesgen mytames.dat 1000
+./tamesgen mytames.dat 10000000000
 
 Then you can restart software with same parameters to see less K in benchmark mode or add "-tames tames76.dat" to solve some public key in 76-bit range faster.
 

--- a/tamesgen.cpp
+++ b/tamesgen.cpp
@@ -3,6 +3,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
 #include <string.h>
 #include "utils.h"
 
@@ -40,11 +42,17 @@ int main(int argc, char* argv[])
         }
 
         char* out_file = argv[ci];
-        int count = atoi(argv[ci + 1]);
+        errno = 0;
+        uint64_t count = strtoull(argv[ci + 1], NULL, 10);
+        if (errno == ERANGE)
+        {
+                printf("Count exceeds supported limits\n");
+                return 1;
+        }
         TFastBase* db = new TFastBase();
         db->Header[0] = range;
 
-        for (int i = 0; i < count; i++)
+        for (uint64_t i = 0; i < count; i++)
         {
                 u8 data[3 + DB_REC_LEN];
                 for (int j = 0; j < 3 + DB_REC_LEN; j++)
@@ -54,7 +62,7 @@ int main(int argc, char* argv[])
 
         if (db->SaveToFileBase128(out_file))
         {
-                printf("Generated %d tames to %s\n", count, out_file);
+                printf("Generated %llu tames to %s\n", (unsigned long long)count, out_file);
                 delete db;
                 return 0;
         }


### PR DESCRIPTION
## Summary
- Parse tames count as 64-bit unsigned integer and guard against overflow.
- Iterate and report generated tames using 64-bit types.
- Document 64-bit support for the tames generator count parameter.

## Testing
- `make tamesgen`


------
https://chatgpt.com/codex/tasks/task_e_689d5d01abc0832ea41f19ffab84d8cb