### PR TITLE
Add memory-mapped tames support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Discussion thread: https://bitcointalk.org/index.php?topic=5517607
 
 <b>-max</b>		option to limit max number of operations. For example, value 5.5 limits number of operations to 5.5 * 1.15 * sqrt(range), software stops when the limit is reached. 
 
-<b>-tames</b>		filename with tames. If file not found, software generates tames (option "-max" is required) and saves them to the file. If the file is found, software loads tames to speedup solving. The program first attempts to load a binary file and automatically falls back to Base128 if needed. 
+<b>-tames</b>           filename with tames. If file not found, software generates tames (option "-max" is required) and saves them to the file. If the file is found, software memory-maps the binary tames to speed up access and automatically falls back to in-memory loading or Base128 if needed.
 
 When public key is solved, software displays it and also writes it to "RESULTS.TXT" file. 
 
@@ -43,9 +43,10 @@ RCKangaroo.exe -dp 16 -range 84 -start 1000000000000000000000 -pubkey 0329c4574a
 Sample command to generate tames:
 
 RCKangaroo.exe -dp 16 -range 76 -tames tames76.dat -max 10
-You can also quickly generate a base128 tames file using the helper tool (count parameter supports 64-bit values):
+You can also quickly generate a tames file using the helper tool (count parameter supports 64-bit values):
 
-./tamesgen mytames.dat 10000000000
+./tamesgen -range 76 tames76.dat 10000000000
+Add the <code>-base128</code> flag to emit a Base128 encoded file instead of the default binary format.
 
 Then you can restart software with same parameters to see less K in benchmark mode or add "-tames tames76.dat" to solve some public key in 76-bit range faster.
 

--- a/tamesgen.cpp
+++ b/tamesgen.cpp
@@ -1,4 +1,4 @@
-// Simple utility to generate a base128 encoded tames file
+// Simple utility to generate a tames file
 // This tool creates random tames records for testing purposes.
 
 #include <stdio.h>
@@ -13,6 +13,7 @@
 int main(int argc, char* argv[])
 {
         int range = 0;
+        bool base128 = false;
         int ci = 1;
         while (ci < argc && argv[ci][0] == '-')
         {
@@ -22,22 +23,26 @@ int main(int argc, char* argv[])
                 {
                         if (ci >= argc)
                         {
-                                printf("Usage: %s -range <bits(32-170)> <output_file> <count>\n", argv[0]);
+                                printf("Usage: %s -range <bits(32-170)> [-base128] <output_file> <count>\n", argv[0]);
                                 return 1;
                         }
                         range = atoi(argv[ci]);
                         ci++;
                 }
+                else if (strcmp(argument, "-base128") == 0)
+                {
+                        base128 = true;
+                }
                 else
                 {
-                        printf("Usage: %s -range <bits(32-170)> <output_file> <count>\n", argv[0]);
+                        printf("Usage: %s -range <bits(32-170)> [-base128] <output_file> <count>\n", argv[0]);
                         return 1;
                 }
         }
 
         if ((range < 32) || (range > 170) || (argc - ci < 2))
         {
-                printf("Usage: %s -range <bits(32-170)> <output_file> <count>\n", argv[0]);
+                printf("Usage: %s -range <bits(32-170)> [-base128] <output_file> <count>\n", argv[0]);
                 return 1;
         }
 
@@ -60,7 +65,8 @@ int main(int argc, char* argv[])
                 db->AddDataBlock(data);
         }
 
-        if (db->SaveToFileBase128(out_file))
+        bool ok = base128 ? db->SaveToFileBase128(out_file) : db->SaveToFile(out_file);
+        if (ok)
         {
                 printf("Generated %llu tames to %s\n", (unsigned long long)count, out_file);
                 delete db;
@@ -71,4 +77,3 @@ int main(int argc, char* argv[])
         delete db;
         return 1;
 }
-

--- a/utils.h
+++ b/utils.h
@@ -86,23 +86,38 @@ public:
 class TFastBase
 {
 private:
-	MemPool mps[256];
-	TListRec lists[256][256][256];
-	int lower_bound(TListRec* list, int mps_ind, u8* data);
-public:
-	u8 Header[256];
+        MemPool mps[256];
+        TListRec lists[256][256][256];
+        int lower_bound(TListRec* list, int mps_ind, u8* data);
+        int lower_bound_mapped(TListRec* list, u8* data);
 
-	TFastBase();
-	~TFastBase();
-	void Clear();
-	u8* AddDataBlock(u8* data, int pos = -1);
-	u8* FindDataBlock(u8* data);
-	u8* FindOrAddDataBlock(u8* data);
+#ifdef _WIN32
+        HHANDLER hFile;
+        HHANDLER hMap;
+#else
+        int fd;
+#endif
+        u8* mapped_ptr;
+        size_t mapped_size;
+        bool mapped_mode;
+public:
+        u8 Header[256];
+
+        TFastBase();
+        ~TFastBase();
+        void Clear();
+        u8* AddDataBlock(u8* data, int pos = -1);
+        u8* FindDataBlock(u8* data);
+        u8* FindOrAddDataBlock(u8* data);
         u64 GetBlockCnt();
         bool LoadFromFile(char* fn);
         bool SaveToFile(char* fn);
         bool LoadFromFileBase128(char* fn);
         bool SaveToFileBase128(char* fn);
+        bool OpenMapped(char* fn);
+        void CloseMapped();
+        u8* FindDataBlockMapped(u8* data);
+        bool IsMapped();
 };
 
 bool IsFileExist(char* fn);


### PR DESCRIPTION
## Summary
- add mmap/CreateFileMapping based tames access with OpenMapped/CloseMapped helpers
- load tames via memory mapping in `RCKangaroo.cpp` with in-memory fallback
- allow `tamesgen` to emit binary or Base128 tames and document memory-mapped mode

## Testing
- `make tamesgen`

------
https://chatgpt.com/codex/tasks/task_e_689d9f77a42c832e8593fadc376a3258