### PR TITLE
Wrap 192-bit distance macros in do-while blocks

### DIFF
--- a/RCGpuCore.cu
+++ b/RCGpuCore.cu
@@ -516,10 +516,10 @@ __device__ __forceinline__ bool ProcessJumpDistance(u32 step_ind, u32 d_cur, u64
 	((int4*)(jmp))[0] = ((int4*)(jmp_d + 4 * (d_cur & JMP_MASK)))[0];
 	jmp[2] = *(jmp_d + 4 * (d_cur & JMP_MASK) + 2);
 
-	if (d_cur & INV_FLAG)
-		Sub192from192(d, jmp)
-	else
-		Add192to192(d, jmp);
+        if (d_cur & INV_FLAG)
+                Sub192from192(d, jmp);
+        else
+                Add192to192(d, jmp);
 
 	//check in table
 	int found_ind = iter + MD_LEN - 4;

--- a/RCGpuUtils.h
+++ b/RCGpuUtils.h
@@ -59,15 +59,17 @@
 #define P_123		0xFFFFFFFFFFFFFFFFull
 #define P_INV32		0x000003D1
 
-#define Add192to192(res, val) { \
+#define Add192to192(res, val) do { \
   add_cc_64((res)[0], (res)[0], (val)[0]); \
   addc_cc_64((res)[1], (res)[1], (val)[1]); \
-  addc_64((res)[2], (res)[2], (val)[2]); }
+  addc_64((res)[2], (res)[2], (val)[2]); \
+} while (0)
 
-#define Sub192from192(res, val) { \
+#define Sub192from192(res, val) do { \
   sub_cc_64((res)[0], (res)[0], (val)[0]); \
   subc_cc_64((res)[1], (res)[1], (val)[1]); \
-  subc_64((res)[2], (res)[2], (val)[2]); }
+  subc_64((res)[2], (res)[2], (val)[2]); \
+} while (0)
 
 #define Copy_int4_x2(dst, src) {\
   ((int4*)(dst))[0] = ((int4*)(src))[0]; \


### PR DESCRIPTION
## Summary
- wrap Add192to192 and Sub192from192 macros in do-while(0) blocks for safer single-statement use
- ensure all Add192to192/Sub192from192 call sites terminate with a semicolon

## Testing
- `make` *(fails: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ee2da64a4832e9ec8cb269d5686a4