### PR TITLE
Add Base128 tames output option

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -527,7 +527,11 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
 		{
                         printf("saving tames...\r\n");
                         db.Header[0] = gRange;
-                        bool ok = gTamesBase128 ? db.SaveToFileBase128(gTamesFileName) : db.SaveToFile(gTamesFileName);
+                        bool ok;
+                        if (gTamesBase128)
+                                ok = db.SaveToFileBase128(gTamesFileName);
+                        else
+                                ok = db.SaveToFile(gTamesFileName);
                         if (ok)
                                 printf("tames saved\r\n");
                         else
@@ -624,22 +628,27 @@ bool ParseCommandLine(int argc, char* argv[])
                 }
                 else
                 if (strcmp(argument, "-max") == 0)
-		{
-			double val = atof(argv[ci]);
-			ci++;
-			if (val < 0.001)
-			{
-				printf("error: invalid value for -max option\r\n");
-				return false;
-			}
-			gMax = val;
-		}
-		else
-		{
-			printf("error: unknown option %s\r\n", argument);
-			return false;
-		}
-	}
+                {
+                        double val = atof(argv[ci]);
+                        ci++;
+                        if (val < 0.001)
+                        {
+                                printf("error: invalid value for -max option\r\n");
+                                return false;
+                        }
+                        gMax = val;
+                }
+                else
+                if (strcmp(argument, "-base128") == 0)
+                {
+                        gTamesBase128 = true;
+                }
+                else
+                {
+                        printf("error: unknown option %s\r\n", argument);
+                        return false;
+                }
+        }
 	if (!gPubKey.x.IsZero())
 		if (!gStartSet || !gRange || !gDP)
 		{

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Discussion thread: https://bitcointalk.org/index.php?topic=5517607
 
 <b>-tames</b>           filename with tames. If file not found, software generates tames (option "-max" is required) and saves them to the file. If the file is found, software memory-maps the binary tames to speed up access and automatically falls back to in-memory loading or Base128 if needed.
 
+<b>-base128</b>        when generating tames, save the output file in Base128 format instead of the default binary format.
+
 When public key is solved, software displays it and also writes it to "RESULTS.TXT" file. 
 
 Sample command line for puzzle #85:


### PR DESCRIPTION
## Summary
- add `-base128` command line flag to request Base128 tames output
- respect `-base128` when saving generated tames
- document new flag in command line parameters

## Testing
- `make` *(fails: fatal error: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ee6a2ee48832ea4bda7d2c13f6441