### PR TITLE
Add multi-DP host filtering with Bloom checks

### DIFF
--- a/Bloom.h
+++ b/Bloom.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+
+class BloomFilter {
+    std::vector<uint8_t> bits;
+    uint64_t mask;
+    int k;
+    static inline uint64_t mix(uint64_t x) {
+        x ^= x >> 33;
+        x *= 0xff51afd7ed558ccdULL;
+        x ^= x >> 33;
+        x *= 0xc4ceb9fe1a85ec53ULL;
+        x ^= x >> 33;
+        return x;
+    }
+public:
+    BloomFilter() : mask(0), k(0) {}
+    void Init(int mbits, int k_){
+        uint64_t size = 1ULL << mbits;
+        bits.assign((size + 7) / 8, 0);
+        mask = size - 1;
+        k = k_;
+    }
+    void Add(uint64_t key){
+        uint64_t h = key;
+        for(int i=0;i<k;i++){
+            h = mix(h + i*0x9e3779b97f4a7c15ULL);
+            uint64_t bit = h & mask;
+            bits[bit >> 3] |= (1u << (bit & 7));
+        }
+    }
+    bool Test(uint64_t key) const{
+        uint64_t h = key;
+        for(int i=0;i<k;i++){
+            h = mix(h + i*0x9e3779b97f4a7c15ULL);
+            uint64_t bit = h & mask;
+            if((bits[bit >> 3] & (1u << (bit & 7)))==0)
+                return false;
+        }
+        return true;
+    }
+};

--- a/GpuKang.cpp
+++ b/GpuKang.cpp
@@ -15,6 +15,8 @@ void CallGpuKernelGen(TKparams Kparams);
 void CallGpuKernelABC(TKparams Kparams);
 void AddPointsToList(u32* data, int cnt, u64 ops_cnt);
 extern bool gGenMode; //tames generation mode
+extern bool gMultiDP;
+extern int gDpCoarseOffset;
 
 extern __device__ __constant__ u64 BETA[4];
 extern __device__ __constant__ u64 BETA2[4];
@@ -52,9 +54,11 @@ bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJump
 	Kparams.BlockSize = IsOldGpu ? 512 : 256;
 	Kparams.GroupCnt = IsOldGpu ? 64 : 24;
 	KangCnt = Kparams.BlockSize * Kparams.GroupCnt * Kparams.BlockCnt;
-	Kparams.KangCnt = KangCnt;
-	Kparams.DP = DP;
-	Kparams.KernelA_LDS_Size = 64 * JMP_CNT + 16 * Kparams.BlockSize;
+        Kparams.KangCnt = KangCnt;
+        Kparams.DP = DP;
+        if (gMultiDP)
+                printf("GPU %d using coarse DP %d (offset %d)\n", CudaIndex, DP, gDpCoarseOffset);
+        Kparams.KernelA_LDS_Size = 64 * JMP_CNT + 16 * Kparams.BlockSize;
 	Kparams.KernelB_LDS_Size = 64 * JMP_CNT;
 	Kparams.KernelC_LDS_Size = 96 * JMP_CNT;
 	Kparams.IsGenMode = gGenMode;


### PR DESCRIPTION
## Summary
- Support multi-DP mode with coarse predicate and Bloom filter to reduce host DP storage
- Add CLI flags for multi-DP tuning and Bloom filter sizing
- Propagate multi-DP settings into GPU preparation

## Testing
- `make` *(fails: fatal error: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ef1914fb0832eb42bfe870a994334