### PR TITLE
Add optional phi-fold control for tames generation

### DIFF
--- a/GpuKang.cpp
+++ b/GpuKang.cpp
@@ -30,7 +30,7 @@ int RCGpuKang::CalcKangCnt()
 }
 
 //executes in main thread
-bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJumps1, EcJMP* _EcJumps2, EcJMP* _EcJumps3)
+bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJumps1, EcJMP* _EcJumps2, EcJMP* _EcJumps3, bool phiFold)
 {
 	PntToSolve = _PntToSolve;
 	Range = _Range;
@@ -60,8 +60,9 @@ bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJump
                 printf("GPU %d using coarse DP %d (offset %d)\n", CudaIndex, DP, gDpCoarseOffset);
         Kparams.KernelA_LDS_Size = 64 * JMP_CNT + 16 * Kparams.BlockSize;
 	Kparams.KernelB_LDS_Size = 64 * JMP_CNT;
-	Kparams.KernelC_LDS_Size = 96 * JMP_CNT;
-	Kparams.IsGenMode = gGenMode;
+        Kparams.KernelC_LDS_Size = 96 * JMP_CNT;
+        Kparams.IsGenMode = gGenMode;
+        Kparams.PhiFold = phiFold;
 
 //allocate gpu mem
 	u64 size;

--- a/GpuKang.h
+++ b/GpuKang.h
@@ -65,7 +65,7 @@ public:
 	bool IsOldGpu;
 
 	int CalcKangCnt();
-	bool Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJumps1, EcJMP* _EcJumps2, EcJMP* _EcJumps3);
+        bool Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJumps1, EcJMP* _EcJumps2, EcJMP* _EcJumps3, bool phiFold);
 	void Stop();
 	void Execute();
 

--- a/RCGpuCore.cu
+++ b/RCGpuCore.cu
@@ -530,7 +530,16 @@ __device__ __forceinline__ void BuildDP(const TKparams& Kparams, int kang_ind, u
 		return;
         int4 rx = *(int4*)(Kparams.DPTable + Kparams.KangCnt + (kang_ind * DPTABLE_MAX_CNT + ind) * 4);
         __align__(16) u64 x_can[4];
-        u32 k = pick_phi_k_and_xcan((u64*)&rx, x_can);
+        u32 k;
+        if (Kparams.PhiFold)
+                k = pick_phi_k_and_xcan((u64*)&rx, x_can);
+        else
+        {
+                ((int4*)x_can)[0] = rx;
+                x_can[2] = 0;
+                x_can[3] = 0;
+                k = 0;
+        }
         u32 pos = atomicAdd(Kparams.DPs_out, 1);
         pos = min(pos, MAX_DP_CNT - 1);
         u32* DPs = Kparams.DPs_out + 4 + pos * GPU_DP_SIZE / 4;

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Discussion thread: https://bitcointalk.org/index.php?topic=5517607
 
 <b>-base128</b>        when generating tames, save the output file in Base128 format instead of the default binary format.
 
-<b>--phi-fold</b>      fold points under the secp256k1 endomorphism φ when generating tames. Example: "--phi-fold 2" uses both P and φ(P) to shrink the tame set and improve cache locality.
+<b>--phi-fold</b>      fold points under the secp256k1 endomorphism φ when generating tames (non-zero to enable, 0 to disable; default enabled). Example: "--phi-fold 2" uses both P and φ(P) to shrink the tame set and improve cache locality.
 
 <b>--multi-dp</b>      allow multiple distinguished-point tables (1 to enable, 0 to disable). Disabling may save memory at the cost of more DP collisions.
 

--- a/defs.h
+++ b/defs.h
@@ -87,11 +87,12 @@ struct TKparams
 	u64* LastPnts;
 	u64* LoopTable;
 	u32* dbg_buf;
-	u32* LoopedKangs;
-	bool IsGenMode; //tames generation mode
+        u32* LoopedKangs;
+        bool IsGenMode; //tames generation mode
+        bool PhiFold;   //enable endomorphism folding
 
-	u32 KernelA_LDS_Size;
-	u32 KernelB_LDS_Size;
-	u32 KernelC_LDS_Size;	
+        u32 KernelA_LDS_Size;
+        u32 KernelB_LDS_Size;
+        u32 KernelC_LDS_Size;
 };
 


### PR DESCRIPTION
## Summary
- add `--phi-fold` CLI option to toggle secp256k1 endomorphism folding
- plumb phi-fold flag through GPU setup and kernels so folding can be disabled
- document `--phi-fold` behaviour in README

## Testing
- `make` *(fails: nvcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f04efd1b4832e955a23b22eb108c9