### PR TITLE
Add streaming tames writer

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -137,4 +137,10 @@ public:
         bool IsMapped();
 };
 
+// Streaming writer for tames records
+struct TamesRecordWriter;
+TamesRecordWriter* TamesRecordWriterOpen(const char* path, bool base128, size_t rec_size, u64 prealloc_recs = 0);
+bool TamesRecordWriterWrite(TamesRecordWriter* wr, const u8* data);
+void TamesRecordWriterClose(TamesRecordWriter* wr);
+
 bool IsFileExist(char* fn);


### PR DESCRIPTION
## Summary
- Implement `TamesRecordWriter` to stream DP records directly to disk with optional mmap-based binary output and Base128 support.
- Hook RCKangaroo and tamesgen into the new writer so tames can be generated without holding the whole table in RAM.
- Allow pre-sizing of mmap'd binary outputs to avoid reallocations.

## Testing
- `make -s` *(fails: cuda_runtime.h: No such file or directory)*
- `make tamesgen`


------
https://chatgpt.com/codex/tasks/task_e_689f0e15d2dc832e84dd2d4a2bb74f35