### PR TITLE
Clarify Base128 tames decoding requirements

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -414,7 +414,10 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
                                 printf("binary tames loading failed, trying legacy Base128...\r\n");
                                 ok = db.LoadFromFileBase128(gTamesFileName);
                                 if (ok)
+                                {
                                         gTamesBase128 = true;
+                                        printf("Base128 tames cannot be memory-mapped and require full in-memory decoding.\r\n");
+                                }
                         }
                         else
                                 gTamesBase128 = false;
@@ -978,7 +981,10 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
                                 printf("binary tames loading failed, trying legacy Base128...\r\n");
                                 ok = db.LoadFromFileBase128(gTamesFileName);
                                 if (ok)
+                                {
                                         gTamesBase128 = true;
+                                        printf("Base128 tames cannot be memory-mapped and require full in-memory decoding.\r\n");
+                                }
                         }
                         else
                                 gTamesBase128 = false;

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ RCKangaroo.exe -dp 16 -range 76 -tames t76.dat -max 10 --phi-fold 2
 RCKangaroo.exe -dp 16 -range 84 -start 1000000000000000000000 -pubkey 0329c4574a4fd8c810b7e42a4b398882b381bcd85e40c6883712912d167c83e73a --multi-dp 1 --bloom-mbits 27 --bloom-k 4
   enable multiple DP tables and tune the Bloom filter parameters.
 
-Binary tames load much faster because the OS can memory-map them directly. Base128 files are smaller but must be decoded at
+Binary tames load much faster because the OS can memory-map them directly. Base128 files are smaller but cannot be memory-mapped and must be fully decoded into RAM at
 startup. Switch between the formats by regenerating the file with or without the <code>-base128</code> flag.
 
 <b>Binary tames header format:</b>

--- a/utils.h
+++ b/utils.h
@@ -129,7 +129,7 @@ public:
         u64 GetBlockCnt();
         bool LoadFromFile(char* fn);
         bool SaveToFile(char* fn);
-        bool LoadFromFileBase128(char* fn); // legacy Base128 support, prefer binary pmap
+        bool LoadFromFileBase128(char* fn); // legacy Base128 support; cannot be memory-mapped and requires full in-memory decoding
         bool SaveToFileBase128(char* fn);   // legacy Base128 support, prefer binary pmap
         bool OpenMapped(char* fn);
         void CloseMapped();


### PR DESCRIPTION
## Summary
- Clarify in README and headers that Base128 tame files cannot be memory-mapped and must be fully decoded into RAM
- Warn at runtime when falling back to Base128 tames that they require full in-memory decoding

## Testing
- `make` *(fails: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f12cbc178832e823b9f611a78abef