### PR TITLE
Build GpuKang.cpp with nvcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,33 @@
 CC := g++
-NVCC := /usr/local/cuda-12.0/bin/nvcc
-CUDA_PATH ?= /usr/local/cuda-12.0
+NVCC := /usr/local/cuda/bin/nvcc
+CUDA_PATH ?= /usr/local/cuda
 
 CCFLAGS := -O3 -I$(CUDA_PATH)/include
 NVCCFLAGS := -O3 -gencode=arch=compute_89,code=compute_89 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_75,code=compute_75 -gencode=arch=compute_61,code=compute_61
-LDFLAGS := -L$(CUDA_PATH)/lib64 -lcudart -pthread
+LDFLAGS := -L$(CUDA_PATH)/lib64 -lcudart -Xcompiler -pthread
 
-CPU_SRC := RCKangaroo.cpp GpuKang.cpp Ec.cpp utils.cpp
+CPU_SRC := RCKangaroo.cpp Ec.cpp utils.cpp
 GPU_SRC := RCGpuCore.cu
+GPU_CPP_SRC := GpuKang.cpp
 
 CPP_OBJECTS := $(CPU_SRC:.cpp=.o)
-CU_OBJECTS := $(GPU_SRC:.cu=.o)
+CU_OBJECTS := $(GPU_SRC:.cu=.o) $(GPU_CPP_SRC:.cpp=.o)
 
 TARGET := rckangaroo
 
 all: $(TARGET) tamesgen
 
 $(TARGET): $(CPP_OBJECTS) $(CU_OBJECTS)
-	$(CC) $(CCFLAGS) -o $@ $^ $(LDFLAGS)
+	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(LDFLAGS)
 
 %.o: %.cpp
 	$(CC) $(CCFLAGS) -c $< -o $@
 
 %.o: %.cu
 	$(NVCC) $(NVCCFLAGS) -c $< -o $@
+
+GpuKang.o: GpuKang.cpp
+	$(NVCC) $(NVCCFLAGS) -x cu -c $< -o $@
 
 clean:
 	rm -f $(CPP_OBJECTS) $(CU_OBJECTS) tamesgen tamesgen.o


### PR DESCRIPTION
## Summary
- Compile GpuKang.cpp with NVCC and link the application using NVCC so device-side symbols like BETA/BETA2 expose host stubs.
- Pass pthread flag through NVCC with `-Xcompiler -pthread` and add an explicit NVCC rule for `GpuKang.o`.
- Detect CUDA toolkit from `/usr/local/cuda` for compiler and include paths.

## Testing
- `apt-get update`
- `apt-get install -y libboost-all-dev`
- `make NVCCFLAGS="-O3 -gencode=arch=compute_89,code=compute_89 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_75,code=compute_75"`


------
https://chatgpt.com/codex/tasks/task_e_689f17a0bf64832e9cc7ab3e8a376cb6