### PR TITLE
Store full x in DP table

### DIFF
--- a/GpuKang.cpp
+++ b/GpuKang.cpp
@@ -146,7 +146,7 @@ bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJump
 		return false;
 	}
 
-	size = (u64)KangCnt * (16 * DPTABLE_MAX_CNT + sizeof(u32)); //we store 16bytes of X
+        size = (u64)KangCnt * (32 * DPTABLE_MAX_CNT + sizeof(u32)); //we store 32bytes of X
 	total_mem += size;
 	err = cudaMallocManaged((void**)&Kparams.DPTable, size);
 	if (err != cudaSuccess)


### PR DESCRIPTION
## Summary
- Store all four 64-bit limbs of x in the DP table and load them for φ folding
- Handle full 256-bit inputs in `pick_phi_k_and_xcan` and `BuildDP`
- Allocate larger DP table capacity for the expanded entries

## Testing
- `make` *(fails: boost/multiprecision/cpp_int.hpp: No such file or directory)*
- `nvcc -c RCGpuCore.cu -o /tmp/RCGpuCore.o`


------
https://chatgpt.com/codex/tasks/task_e_689f1c7a27b0832ea02492aadeb8f2f9