### PR TITLE
Add Base128 format flag and format checks for tames files

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -402,47 +402,55 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
         double DPs_per_kang = path_single_kang / dp_val;
         printf("Estimated DPs per kangaroo: %.3f.%s\r\n", DPs_per_kang, (DPs_per_kang < 5) ? " DP overhead is big, use less DP value if possible!" : "");
 
-        bool tamesRangeMismatch = false;
-        if (!gGenMode && gTamesFileName[0])
-        {
-                printf("load tames...\r\n");
-                bool ok = db.OpenMapped(gTamesFileName);
-                if (!ok)
-                {
-                        printf("memory-mapped tames failed, loading into RAM...\r\n");
-                        ok = db.LoadFromFile(gTamesFileName);
-                        if (!ok)
-                        {
-                                printf("binary tames loading failed, trying legacy Base128...\r\n");
-                                ok = db.LoadFromFileBase128(gTamesFileName);
-                                if (ok)
-                                {
-                                        gTamesBase128 = true;
-                                        printf("Base128 tames cannot be memory-mapped and require full in-memory decoding.\r\n");
-                                }
-                        }
-                        else
-                                gTamesBase128 = false;
-                }
-                else
-                        gTamesBase128 = false;
-                if (ok)
-                {
-                        printf("tames loaded\r\n");
-                        if ((db.Header.flags >> TAMES_RANGE_SHIFT) != gRange)
-                        {
-                                printf("loaded tames have different range, they cannot be used, clear\r\n");
-                                db.Clear();
-                                tamesRangeMismatch = true;
-                                printf("WARNING: tames cleared due to range mismatch, continuing without precomputed tames\r\n");
-                        }
-                }
-                else
-                {
-                        printf("tames loading failed\r\n");
-                        printf("WARNING: tames loading failed, continuing without precomputed tames\r\n");
-                }
-        }
+       bool tamesRangeMismatch = false;
+       if (!gGenMode && gTamesFileName[0])
+       {
+               printf("load tames...\r\n");
+               bool ok = false;
+               if (gTamesBase128)
+               {
+                       ok = db.LoadFromFileBase128(gTamesFileName);
+                       if (ok)
+                               printf("Base128 tames cannot be memory-mapped and require full in-memory decoding.\r\n");
+                       else
+                               printf("Base128 tames loading failed\r\n");
+               }
+               else
+               {
+                       ok = db.OpenMapped(gTamesFileName);
+                       if (!ok)
+                       {
+                               printf("memory-mapped tames failed, loading into RAM...\r\n");
+                               ok = db.LoadFromFile(gTamesFileName);
+                               if (!ok)
+                                       printf("binary tames loading failed\r\n");
+                       }
+               }
+               if (ok)
+               {
+                       bool fileBase128 = (db.Header.flags & TAMES_FLAG_BASE128) != 0;
+                       if (fileBase128 != gTamesBase128)
+                       {
+                               printf("tames format mismatch\r\n");
+                               db.Clear();
+                               ok = false;
+                       }
+                       else if ((db.Header.flags >> TAMES_RANGE_SHIFT) != gRange)
+                       {
+                               printf("loaded tames have different range, they cannot be used, clear\r\n");
+                               db.Clear();
+                               tamesRangeMismatch = true;
+                               printf("WARNING: tames cleared due to range mismatch, continuing without precomputed tames\r\n");
+                       }
+                       else
+                               printf("tames loaded\r\n");
+               }
+               if (!ok)
+               {
+                       printf("tames loading failed\r\n");
+                       printf("WARNING: tames loading failed, continuing without precomputed tames\r\n");
+               }
+       }
 
         if (gGenMode && gTamesFileName[0])
         {
@@ -978,47 +986,55 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
         double DPs_per_kang = path_single_kang / dp_val;
         printf("Estimated DPs per kangaroo: %.3f.%s\r\n", DPs_per_kang, (DPs_per_kang < 5) ? " DP overhead is big, use less DP value if possible!" : "");
 
-        bool tamesRangeMismatch = false;
-        if (!gGenMode && gTamesFileName[0])
-        {
-                printf("load tames...\r\n");
-                bool ok = db.OpenMapped(gTamesFileName);
-                if (!ok)
-                {
-                        printf("memory-mapped tames failed, loading into RAM...\r\n");
-                        ok = db.LoadFromFile(gTamesFileName);
-                        if (!ok)
-                        {
-                                printf("binary tames loading failed, trying legacy Base128...\r\n");
-                                ok = db.LoadFromFileBase128(gTamesFileName);
-                                if (ok)
-                                {
-                                        gTamesBase128 = true;
-                                        printf("Base128 tames cannot be memory-mapped and require full in-memory decoding.\r\n");
-                                }
-                        }
-                        else
-                                gTamesBase128 = false;
-                }
-                else
-                        gTamesBase128 = false;
-                if (ok)
-                {
-                        printf("tames loaded\r\n");
-                        if ((db.Header.flags >> TAMES_RANGE_SHIFT) != gRange)
-                        {
-                                printf("loaded tames have different range, they cannot be used, clear\r\n");
-                                db.Clear();
-                                tamesRangeMismatch = true;
-                                printf("WARNING: tames cleared due to range mismatch, continuing without precomputed tames\r\n");
-                        }
-                }
-                else
-                {
-                        printf("tames loading failed\r\n");
-                        printf("WARNING: tames loading failed, continuing without precomputed tames\r\n");
-                }
-        }
+       bool tamesRangeMismatch = false;
+       if (!gGenMode && gTamesFileName[0])
+       {
+               printf("load tames...\r\n");
+               bool ok = false;
+               if (gTamesBase128)
+               {
+                       ok = db.LoadFromFileBase128(gTamesFileName);
+                       if (ok)
+                               printf("Base128 tames cannot be memory-mapped and require full in-memory decoding.\r\n");
+                       else
+                               printf("Base128 tames loading failed\r\n");
+               }
+               else
+               {
+                       ok = db.OpenMapped(gTamesFileName);
+                       if (!ok)
+                       {
+                               printf("memory-mapped tames failed, loading into RAM...\r\n");
+                               ok = db.LoadFromFile(gTamesFileName);
+                               if (!ok)
+                                       printf("binary tames loading failed\r\n");
+                       }
+               }
+               if (ok)
+               {
+                       bool fileBase128 = (db.Header.flags & TAMES_FLAG_BASE128) != 0;
+                       if (fileBase128 != gTamesBase128)
+                       {
+                               printf("tames format mismatch\r\n");
+                               db.Clear();
+                               ok = false;
+                       }
+                       else if ((db.Header.flags >> TAMES_RANGE_SHIFT) != gRange)
+                       {
+                               printf("loaded tames have different range, they cannot be used, clear\r\n");
+                               db.Clear();
+                               tamesRangeMismatch = true;
+                               printf("WARNING: tames cleared due to range mismatch, continuing without precomputed tames\r\n");
+                       }
+                       else
+                               printf("tames loaded\r\n");
+               }
+               if (!ok)
+               {
+                       printf("tames loading failed\r\n");
+                       printf("WARNING: tames loading failed, continuing without precomputed tames\r\n");
+               }
+       }
 
 	SetRndSeed(0); //use same seed to make tames from file compatible
 	PntTotalOps = 0;
@@ -1140,11 +1156,11 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
                 if (gGenMode)
                 {
                         printf("saving tames...\r\n");
-                        db.Header.flags = (u16)(TAMES_FLAG_LE | (gRange << TAMES_RANGE_SHIFT));
-                        bool ok;
-                        if (gTamesBase128)
-                                ok = db.SaveToFileBase128(gTamesFileName);
-                        else
+                       db.Header.flags = (u16)(TAMES_FLAG_LE | (gRange << TAMES_RANGE_SHIFT) | (gTamesBase128 ? TAMES_FLAG_BASE128 : 0));
+                       bool ok;
+                       if (gTamesBase128)
+                               ok = db.SaveToFileBase128(gTamesFileName);
+                       else
                                 ok = db.SaveToFile(gTamesFileName);
                         if (ok)
                                 printf("tames saved\r\n");

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Discussion thread: https://bitcointalk.org/index.php?topic=5517607
 
 <b>-max</b>		option to limit max number of operations. For example, value 5.5 limits number of operations to 5.5 * 1.15 * sqrt(range), software stops when the limit is reached. 
 
-<b>-tames</b>           filename with tames. If file not found, software generates tames (option "-max" is required) and saves them to the file. If the file is found, software memory-maps the binary tames to speed up access and automatically falls back to in-memory loading or Base128 if needed.
+<b>-tames</b>           filename with tames. If file not found, software generates tames (option "-max" is required) and saves them to the file. Existing tames are assumed to be in the default binary format and are memory-mapped for speed. Use <code>-base128</code> to read or write legacy Base128 files. The program validates the format via a header flag and aborts on mismatch.
 
-<b>-base128</b>        when generating tames, save the output file in Base128 format instead of the default binary format.
+<b>-base128</b>        when generating or loading tames, use the legacy Base128 format instead of the default binary format.
 
 <b>--phi-fold N</b>    fold points under the secp256k1 endomorphism φ when generating tames. 0 disables folding. 1 (default) folds P with φ(P); 2 also considers φ²(P). Higher values are clamped to 2.
 
@@ -72,7 +72,7 @@ RCKangaroo.exe -dp 16 -range 84 -start 1000000000000000000000 -pubkey 0329c4574a
   enable multiple DP tables and tune the Bloom filter parameters.
 
 Binary tames load much faster because the OS can memory-map them directly. Base128 files are smaller but cannot be memory-mapped and must be fully decoded into RAM at
-startup. Switch between the formats by regenerating the file with or without the <code>-base128</code> flag.
+startup. Files are tagged with a header flag and a mismatched format causes the load to fail. Switch between the formats by regenerating the file with or without the <code>-base128</code> flag.
 
 <b>Binary tames header format:</b>
 

--- a/utils.h
+++ b/utils.h
@@ -74,6 +74,7 @@ struct TListRec
 #define TAMES_MAGIC "PMAP"
 #define TAMES_VERSION 1
 #define TAMES_FLAG_LE 0x0001
+#define TAMES_FLAG_BASE128 0x0002
 #define TAMES_RANGE_SHIFT 8
 
 #pragma pack(push, 1)


### PR DESCRIPTION
## Summary
- add `TAMES_FLAG_BASE128` to tag tames file encoding
- use `gTamesBase128` when loading tames and verify header flag to prevent format mismatches
- clarify default binary behaviour and `-base128` usage in README examples

## Testing
- `make` *(fails: nvcc fatal : Unsupported gpu architecture 'compute_61')*

------
https://chatgpt.com/codex/tasks/task_e_689f2646acac832e87c79857d6abbc26