### PR TITLE
Fix constant symbol initialization and host build path

### DIFF
--- a/GpuKang.cpp
+++ b/GpuKang.cpp
@@ -18,8 +18,10 @@ extern bool gGenMode; //tames generation mode
 extern bool gMultiDP;
 extern int gDpCoarseOffset;
 
+extern "C" {
 extern __device__ __constant__ u64 BETA[4];
 extern __device__ __constant__ u64 BETA2[4];
+}
 
 int RCGpuKang::CalcKangCnt()
 {
@@ -246,14 +248,14 @@ bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJump
         {
                 EcInt beta2 = g_Beta;
                 beta2.MulModP(g_Beta);
-                err = cudaMemcpyToSymbol(BETA, g_Beta.data, 32);
+                err = cudaMemcpyToSymbol("BETA", g_Beta.data, 32);
                 if (err != cudaSuccess)
                 {
                         free(jmp2_table);
                         printf("GPU %d, cudaMemcpyToSymbol BETA failed: %s\n", CudaIndex, cudaGetErrorString(err));
                         return false;
                 }
-                err = cudaMemcpyToSymbol(BETA2, beta2.data, 32);
+                err = cudaMemcpyToSymbol("BETA2", beta2.data, 32);
                 if (err != cudaSuccess)
                 {
                         free(jmp2_table);
@@ -264,8 +266,20 @@ bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJump
         else
         {
                 u64 zero[4] = { 0, 0, 0, 0 };
-                cudaMemcpyToSymbol(BETA, zero, 32);
-                cudaMemcpyToSymbol(BETA2, zero, 32);
+                err = cudaMemcpyToSymbol("BETA", zero, 32);
+                if (err != cudaSuccess)
+                {
+                        free(jmp2_table);
+                        printf("GPU %d, cudaMemcpyToSymbol BETA failed: %s\n", CudaIndex, cudaGetErrorString(err));
+                        return false;
+                }
+                err = cudaMemcpyToSymbol("BETA2", zero, 32);
+                if (err != cudaSuccess)
+                {
+                        free(jmp2_table);
+                        printf("GPU %d, cudaMemcpyToSymbol BETA2 failed: %s\n", CudaIndex, cudaGetErrorString(err));
+                        return false;
+                }
         }
         free(jmp2_table);
 //jmp3

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,14 @@ NVCC := /usr/local/cuda/bin/nvcc
 CUDA_PATH ?= /usr/local/cuda
 
 CCFLAGS := -O3 -I$(CUDA_PATH)/include
-NVCCFLAGS := -O3 -gencode=arch=compute_89,code=compute_89 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_75,code=compute_75 -gencode=arch=compute_61,code=compute_61
+NVCCFLAGS := -O3 -gencode=arch=compute_89,code=compute_89 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_75,code=compute_75
 LDFLAGS := -L$(CUDA_PATH)/lib64 -lcudart -Xcompiler -pthread
 
-CPU_SRC := RCKangaroo.cpp Ec.cpp utils.cpp
+CPU_SRC := RCKangaroo.cpp Ec.cpp utils.cpp GpuKang.cpp
 GPU_SRC := RCGpuCore.cu
-GPU_CPP_SRC := GpuKang.cpp
 
 CPP_OBJECTS := $(CPU_SRC:.cpp=.o)
-CU_OBJECTS := $(GPU_SRC:.cu=.o) $(GPU_CPP_SRC:.cpp=.o)
+CU_OBJECTS := $(GPU_SRC:.cu=.o)
 
 TARGET := rckangaroo
 
@@ -26,8 +25,6 @@ $(TARGET): $(CPP_OBJECTS) $(CU_OBJECTS)
 %.o: %.cu
 	$(NVCC) $(NVCCFLAGS) -c $< -o $@
 
-GpuKang.o: GpuKang.cpp
-	$(NVCC) $(NVCCFLAGS) -x cu -c $< -o $@
 
 clean:
 	rm -f $(CPP_OBJECTS) $(CU_OBJECTS) tamesgen tamesgen.o

--- a/RCGpuCore.cu
+++ b/RCGpuCore.cu
@@ -11,8 +11,10 @@
 __device__ __constant__ u64 jmp2_table[8 * JMP_CNT];
 
 // endomorphism constants
+extern "C" {
 __device__ __constant__ u64 BETA[4];
 __device__ __constant__ u64 BETA2[4];
+}
 
 
 #define BLOCK_CNT	gridDim.x


### PR DESCRIPTION
## Summary
- Define BETA/BETA2 in RCGpuCore.cu and declare them with C linkage elsewhere
- Copy constant memory via cudaMemcpyToSymbol using symbol names and abort on error
- Build GpuKang.cpp as host code and drop unsupported GPU arch from NVCC flags

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_689f310260a4832ea8afb19a8d64c9e1