### PR TITLE
Store full canonical x-coordinates in DP records

### DIFF
--- a/RCGpuCore.cu
+++ b/RCGpuCore.cu
@@ -549,14 +549,15 @@ __device__ __forceinline__ void BuildDP(const TKparams& Kparams, int kang_ind, u
                 k = 0;
         }
         rx[0] = ((int4*)x_can)[0];
-        rx[1] = make_int4(0, 0, 0, 0);
+        rx[1] = ((int4*)x_can)[1];
         u32 pos = atomicAdd(Kparams.DPs_out, 1);
         pos = min(pos, MAX_DP_CNT - 1);
         u32* DPs = Kparams.DPs_out + 4 + pos * GPU_DP_SIZE / 4;
         *(int4*)&DPs[0] = ((int4*)x_can)[0];
-        *(int4*)&DPs[4] = ((int4*)d)[0];
-        *(u64*)&DPs[8] = d[2];
-        DPs[10] = (k << 2) | (3 * kang_ind / Kparams.KangCnt); //kang type + phi k
+        *(int4*)&DPs[4] = ((int4*)x_can)[1];
+        *(int4*)&DPs[8] = ((int4*)d)[0];
+        *(u64*)&DPs[12] = d[2];
+        DPs[14] = (k << 2) | (3 * kang_ind / Kparams.KangCnt); //kang type + phi k
 }
 
 __device__ __forceinline__ bool ProcessJumpDistance(u32 step_ind, u32 d_cur, u64* d, u32 kang_ind, u64* jmp1_d, u64* jmp2_d, const TKparams& Kparams, u64* table, u32* cur_ind, u8 iter)

--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -252,8 +252,8 @@ void CheckNewPoints()
 
                 DBRec nrec;
                 memcpy(nrec.x, p, 12);
-                memcpy(nrec.d, p + 16, 22);
-                u8 type_byte = gGenMode ? TAME : p[40];
+                memcpy(nrec.d, p + 32, 22);
+                u8 type_byte = gGenMode ? TAME : p[56];
                 u8 nrec_k = type_byte >> 2;
                 u8 nrec_type = type_byte & 3;
                 nrec.type = type_byte;

--- a/defs.h
+++ b/defs.h
@@ -50,7 +50,7 @@ typedef char i8;
 #define WILD1				1  // Wild kangs1 
 #define WILD2				2  // Wild kangs2
 
-#define GPU_DP_SIZE			48
+#define GPU_DP_SIZE                     64
 #define MAX_DP_CNT			(256 * 1024)
 
 #define JMP_MASK			(JMP_CNT-1)


### PR DESCRIPTION
## Summary
- Preserve all 256 bits of canonical x-coordinates in GPU DPTable and output buffer
- Expand GPU DP entry size and adjust host-side parsing for new layout

## Testing
- `make` *(fails: boost/multiprecision/cpp_int.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f5ce2f7ec832eb82530b4a587317e