### PR TITLE
Auto-detect tames format and default to binary generation

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -407,44 +407,64 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
        {
                printf("load tames...\r\n");
                bool ok = false;
-               if (gTamesBase128)
+               bool fileBase128 = false;
+
+               FILE* tfp = fopen(gTamesFileName, "rb");
+               if (tfp)
                {
-                       ok = db.LoadFromFileBase128(gTamesFileName);
-                       if (ok)
-                               printf("Base128 tames cannot be memory-mapped and require full in-memory decoding.\r\n");
+                       u8 magic[4];
+                       if (fread(magic, 1, 4, tfp) == 4)
+                               fileBase128 = memcmp(magic, TAMES_MAGIC, 4) != 0;
                        else
-                               printf("Base128 tames loading failed\r\n");
+                               printf("tames header read failed\r\n");
+                       fclose(tfp);
                }
+
+               if (fileBase128 != gTamesBase128)
+                       printf("tames format mismatch\r\n");
                else
                {
-                       ok = db.OpenMapped(gTamesFileName);
-                       if (!ok)
+                       if (fileBase128)
                        {
-                               printf("memory-mapped tames failed, loading into RAM...\r\n");
-                               ok = db.LoadFromFile(gTamesFileName);
-                               if (!ok)
-                                       printf("binary tames loading failed\r\n");
-                       }
-               }
-               if (ok)
-               {
-                       bool fileBase128 = (db.Header.flags & TAMES_FLAG_BASE128) != 0;
-                       if (fileBase128 != gTamesBase128)
-                       {
-                               printf("tames format mismatch\r\n");
-                               db.Clear();
-                               ok = false;
-                       }
-                       else if ((db.Header.flags >> TAMES_RANGE_SHIFT) != gRange)
-                       {
-                               printf("loaded tames have different range, they cannot be used, clear\r\n");
-                               db.Clear();
-                               tamesRangeMismatch = true;
-                               printf("WARNING: tames cleared due to range mismatch, continuing without precomputed tames\r\n");
+                               ok = db.LoadFromFileBase128(gTamesFileName);
+                               if (ok)
+                                       printf("Base128 tames cannot be memory-mapped and require full in-memory decoding.\r\n");
+                               else
+                                       printf("Base128 tames loading failed\r\n");
                        }
                        else
-                               printf("tames loaded\r\n");
+                       {
+                               ok = db.OpenMapped(gTamesFileName);
+                               if (!ok)
+                               {
+                                       printf("memory-mapped tames failed, loading into RAM...\r\n");
+                                       ok = db.LoadFromFile(gTamesFileName);
+                                       if (!ok)
+                                               printf("binary tames loading failed\r\n");
+                               }
+                       }
+
+                       if (ok)
+                       {
+                               bool hdrBase128 = (db.Header.flags & TAMES_FLAG_BASE128) != 0;
+                               if (hdrBase128 != fileBase128)
+                               {
+                                       printf("tames format mismatch\r\n");
+                                       db.Clear();
+                                       ok = false;
+                               }
+                               else if ((db.Header.flags >> TAMES_RANGE_SHIFT) != gRange)
+                               {
+                                       printf("loaded tames have different range, they cannot be used, clear\r\n");
+                                       db.Clear();
+                                       tamesRangeMismatch = true;
+                                       printf("WARNING: tames cleared due to range mismatch, continuing without precomputed tames\r\n");
+                               }
+                               else
+                                       printf("tames loaded\r\n");
+                       }
                }
+
                if (!ok)
                {
                        printf("tames loading failed\r\n");
@@ -991,44 +1011,64 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
        {
                printf("load tames...\r\n");
                bool ok = false;
-               if (gTamesBase128)
+               bool fileBase128 = false;
+
+               FILE* tfp = fopen(gTamesFileName, "rb");
+               if (tfp)
                {
-                       ok = db.LoadFromFileBase128(gTamesFileName);
-                       if (ok)
-                               printf("Base128 tames cannot be memory-mapped and require full in-memory decoding.\r\n");
+                       u8 magic[4];
+                       if (fread(magic, 1, 4, tfp) == 4)
+                               fileBase128 = memcmp(magic, TAMES_MAGIC, 4) != 0;
                        else
-                               printf("Base128 tames loading failed\r\n");
+                               printf("tames header read failed\r\n");
+                       fclose(tfp);
                }
+
+               if (fileBase128 != gTamesBase128)
+                       printf("tames format mismatch\r\n");
                else
                {
-                       ok = db.OpenMapped(gTamesFileName);
-                       if (!ok)
+                       if (fileBase128)
                        {
-                               printf("memory-mapped tames failed, loading into RAM...\r\n");
-                               ok = db.LoadFromFile(gTamesFileName);
-                               if (!ok)
-                                       printf("binary tames loading failed\r\n");
-                       }
-               }
-               if (ok)
-               {
-                       bool fileBase128 = (db.Header.flags & TAMES_FLAG_BASE128) != 0;
-                       if (fileBase128 != gTamesBase128)
-                       {
-                               printf("tames format mismatch\r\n");
-                               db.Clear();
-                               ok = false;
-                       }
-                       else if ((db.Header.flags >> TAMES_RANGE_SHIFT) != gRange)
-                       {
-                               printf("loaded tames have different range, they cannot be used, clear\r\n");
-                               db.Clear();
-                               tamesRangeMismatch = true;
-                               printf("WARNING: tames cleared due to range mismatch, continuing without precomputed tames\r\n");
+                               ok = db.LoadFromFileBase128(gTamesFileName);
+                               if (ok)
+                                       printf("Base128 tames cannot be memory-mapped and require full in-memory decoding.\r\n");
+                               else
+                                       printf("Base128 tames loading failed\r\n");
                        }
                        else
-                               printf("tames loaded\r\n");
+                       {
+                               ok = db.OpenMapped(gTamesFileName);
+                               if (!ok)
+                               {
+                                       printf("memory-mapped tames failed, loading into RAM...\r\n");
+                                       ok = db.LoadFromFile(gTamesFileName);
+                                       if (!ok)
+                                               printf("binary tames loading failed\r\n");
+                               }
+                       }
+
+                       if (ok)
+                       {
+                               bool hdrBase128 = (db.Header.flags & TAMES_FLAG_BASE128) != 0;
+                               if (hdrBase128 != fileBase128)
+                               {
+                                       printf("tames format mismatch\r\n");
+                                       db.Clear();
+                                       ok = false;
+                               }
+                               else if ((db.Header.flags >> TAMES_RANGE_SHIFT) != gRange)
+                               {
+                                       printf("loaded tames have different range, they cannot be used, clear\r\n");
+                                       db.Clear();
+                                       tamesRangeMismatch = true;
+                                       printf("WARNING: tames cleared due to range mismatch, continuing without precomputed tames\r\n");
+                               }
+                               else
+                                       printf("tames loaded\r\n");
+                       }
                }
+
                if (!ok)
                {
                        printf("tames loading failed\r\n");

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Discussion thread: https://bitcointalk.org/index.php?topic=5517607
 
 <b>-max</b>		option to limit max number of operations. For example, value 5.5 limits number of operations to 5.5 * 1.15 * sqrt(range), software stops when the limit is reached. 
 
-<b>-tames</b>           filename with tames. If file not found, software generates tames (option "-max" is required) and saves them to the file. Existing tames are assumed to be in the default binary format and are memory-mapped for speed. Use <code>-base128</code> to read or write legacy Base128 files. The program validates the format via a header flag and aborts on mismatch.
+<b>-tames</b>           filename with tames. If file not found, software generates tames (option "-max" is required) and saves them to the file. The loader inspects the file header to auto-detect whether the tames are in binary or Base128 format. Binary files are memory-mapped for speed, while Base128 files must be fully decoded. Use <code>-base128</code> to read or write legacy Base128 files. A mismatch between the detected format and the <code>-base128</code> flag aborts the load.
 
 <b>-base128</b>        when generating or loading tames, use the legacy Base128 format instead of the default binary format.
 
@@ -71,8 +71,7 @@ RCKangaroo.exe -dp 16 -range 76 -tames t76.dat -max 10 --phi-fold 2
 RCKangaroo.exe -dp 16 -range 84 -start 1000000000000000000000 -pubkey 0329c4574a4fd8c810b7e42a4b398882b381bcd85e40c6883712912d167c83e73a --multi-dp 1 --bloom-mbits 27 --bloom-k 4
   enable multiple DP tables and tune the Bloom filter parameters.
 
-Binary tames load much faster because the OS can memory-map them directly. Base128 files are smaller but cannot be memory-mapped and must be fully decoded into RAM at
-startup. Files are tagged with a header flag and a mismatched format causes the load to fail. Switch between the formats by regenerating the file with or without the <code>-base128</code> flag.
+Binary tames load much faster because the OS can memory-map them directly. Base128 files are smaller but cannot be memory-mapped and must be fully decoded into RAM at startup. The loader inspects the header to determine the format and fails if it does not match the <code>-base128</code> option. Switch between the formats by regenerating the file with or without the <code>-base128</code> flag.
 
 <b>Binary tames header format:</b>
 


### PR DESCRIPTION
## Summary
- Automatically detect tames file format from header before loading
- Fail fast when file format conflicts with `-base128` flag
- Document header-based format detection and binary default in README

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_689f6e012b6c832e99c36eb801b56780