### PR TITLE
Assert DP k consistency and test lambda adjustments

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -306,6 +306,13 @@ void CheckNewPoints()
                 u8 pref_k = pref->type >> 2;
                 u8 pref_type = pref->type & 3;
 
+                if (pref_k != nrec_k)
+                {
+                        printf("DP collision k mismatch (%u vs %u)\r\n", pref_k, nrec_k);
+                        gTotalErrors++;
+                        continue;
+                }
+
                 if ((pref_type == nrec_type) && (pref_k == nrec_k))
                 {
                         if (pref_type == TAME)

--- a/tests/test_lambda.cpp
+++ b/tests/test_lambda.cpp
@@ -1,0 +1,34 @@
+#include "defs.h"
+#include "Ec.h"
+#include <cassert>
+
+int main()
+{
+    InitEc();
+
+    EcInt key; key.Set(12345);
+    EcInt w; w.Set(0);
+    EcInt t = key; t.Add(w);
+
+    // Scenario with k = 1 (lambda)
+    {
+        EcInt t1 = t, w1 = w;
+        t1.MulLambdaN();
+        w1.MulLambdaN();
+        EcInt res = t1; res.Sub(w1);
+        res.MulLambda2N();
+        assert(res.IsEqual(key));
+    }
+
+    // Scenario with k = 2 (lambda^2)
+    {
+        EcInt t2 = t, w2 = w;
+        t2.MulLambda2N();
+        w2.MulLambda2N();
+        EcInt res = t2; res.Sub(w2);
+        res.MulLambdaN();
+        assert(res.IsEqual(key));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Validate that DP collision entries share the same k bits, logging mismatch errors
- Add synthetic DP unit tests ensuring lambda adjustments reconstruct the correct key

## Testing
- `g++ -std=c++17 -O3 -I. tests/test_lambda.cpp Ec.cpp utils.cpp -o tests/test_lambda && ./tests/test_lambda`


------
https://chatgpt.com/codex/tasks/task_e_689f73a38f0c832e8d9fdc42a993dea1