### PR TITLE
Halt on GPU prepare failure and validate Kparams

### DIFF
--- a/GpuKang.cpp
+++ b/GpuKang.cpp
@@ -345,13 +345,24 @@ void RCGpuKang::GenerateRndDistances()
 
 bool RCGpuKang::Start()
 {
-	if (Failed)
-		return false;
+        if (Failed)
+                return false;
 
-	cudaError_t err;
-	err = cudaSetDevice(CudaIndex);
-	if (err != cudaSuccess)
-		return false;
+        if (!Kparams.KangCnt || !Kparams.Kangs || !Kparams.DPs_out ||
+                !Kparams.Jumps1 || !Kparams.Jumps2 || !Kparams.Jumps3 ||
+                !Kparams.JumpsList || !Kparams.DPTable || !Kparams.L1S2 ||
+                !Kparams.LastPnts || !Kparams.LoopTable || !Kparams.dbg_buf ||
+                !Kparams.LoopedKangs)
+        {
+                printf("GPU %d Kparams incomplete, aborting\n", CudaIndex);
+                Failed = true;
+                return false;
+        }
+
+        cudaError_t err;
+        err = cudaSetDevice(CudaIndex);
+        if (err != cudaSuccess)
+                return false;
 
 	HalfRange.Set(1);
 	HalfRange.ShiftLeft(Range - 1);

--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -544,14 +544,23 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
 //prepare GPUs
         int gpuDP = gMultiDP ? (DP - gDpCoarseOffset) : DP;
         for (int i = 0; i < GpuCnt; i++)
+        {
                 if (!GpuKangs[i]->Prepare(PntToSolve, Range, gpuDP, EcJumps1, EcJumps2, EcJumps3, gPhiFold))
                 {
                         GpuKangs[i]->Failed = true;
                         printf("GPU %d Prepare failed\r\n", GpuKangs[i]->CudaIndex);
+                        if (gGenMode && gTamesWriter)
+                        {
+                                TamesRecordWriterClose(gTamesWriter);
+                                gTamesWriter = NULL;
+                        }
+                        db.Clear();
+                        return false;
                 }
+        }
 
-	u64 tm0 = GetTickCount64();
-	printf("GPUs started...\r\n");
+        u64 tm0 = GetTickCount64();
+        printf("GPUs started...\r\n");
 
 #ifdef _WIN32
 	HANDLE thr_handles[MAX_GPU_CNT];
@@ -1137,14 +1146,23 @@ bool SolvePoint(EcPoint PntToSolve, int Range, int DP, EcInt* pk_res)
 
 //prepare GPUs
         for (int i = 0; i < GpuCnt; i++)
+        {
                 if (!GpuKangs[i]->Prepare(PntToSolve, Range, DP, EcJumps1, EcJumps2, EcJumps3, gPhiFold))
                 {
                         GpuKangs[i]->Failed = true;
                         printf("GPU %d Prepare failed\r\n", GpuKangs[i]->CudaIndex);
+                        if (gGenMode && gTamesWriter)
+                        {
+                                TamesRecordWriterClose(gTamesWriter);
+                                gTamesWriter = NULL;
+                        }
+                        db.Clear();
+                        return false;
                 }
+        }
 
-	u64 tm0 = GetTickCount64();
-	printf("GPUs started...\r\n");
+        u64 tm0 = GetTickCount64();
+        printf("GPUs started...\r\n");
 
 #ifdef _WIN32
 	HANDLE thr_handles[MAX_GPU_CNT];


### PR DESCRIPTION
## Summary
- Abort solving immediately when any GPU fails preparation and clean up resources.
- Guard GPU start-up with a completeness check of Kparams to prevent running kernels with invalid setup.

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make`

------
https://chatgpt.com/codex/tasks/task_e_689f78862264832ea32d254c122733f9