### PR TITLE
Build GpuKang with nvcc and fix cudaMemcpyToSymbol

### DIFF
--- a/GpuKang.cpp
+++ b/GpuKang.cpp
@@ -18,10 +18,8 @@ extern bool gGenMode; //tames generation mode
 extern bool gMultiDP;
 extern int gDpCoarseOffset;
 
-extern "C" {
 extern __device__ __constant__ u64 BETA[4];
 extern __device__ __constant__ u64 BETA2[4];
-}
 
 int RCGpuKang::CalcKangCnt()
 {
@@ -248,14 +246,14 @@ bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJump
         {
                 EcInt beta2 = g_Beta;
                 beta2.MulModP(g_Beta);
-                err = cudaMemcpyToSymbol("BETA", g_Beta.data, 32);
+                err = cudaMemcpyToSymbol(BETA, g_Beta.data, 32);
                 if (err != cudaSuccess)
                 {
                         free(jmp2_table);
                         printf("GPU %d, cudaMemcpyToSymbol BETA failed: %s\n", CudaIndex, cudaGetErrorString(err));
                         return false;
                 }
-                err = cudaMemcpyToSymbol("BETA2", beta2.data, 32);
+                err = cudaMemcpyToSymbol(BETA2, beta2.data, 32);
                 if (err != cudaSuccess)
                 {
                         free(jmp2_table);
@@ -266,14 +264,14 @@ bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJump
         else
         {
                 u64 zero[4] = { 0, 0, 0, 0 };
-                err = cudaMemcpyToSymbol("BETA", zero, 32);
+                err = cudaMemcpyToSymbol(BETA, zero, 32);
                 if (err != cudaSuccess)
                 {
                         free(jmp2_table);
                         printf("GPU %d, cudaMemcpyToSymbol BETA failed: %s\n", CudaIndex, cudaGetErrorString(err));
                         return false;
                 }
-                err = cudaMemcpyToSymbol("BETA2", zero, 32);
+                err = cudaMemcpyToSymbol(BETA2, zero, 32);
                 if (err != cudaSuccess)
                 {
                         free(jmp2_table);

--- a/Makefile
+++ b/Makefile
@@ -3,20 +3,22 @@ NVCC := /usr/local/cuda/bin/nvcc
 CUDA_PATH ?= /usr/local/cuda
 
 CCFLAGS := -O3 -I$(CUDA_PATH)/include
-NVCCFLAGS := -O3 -gencode=arch=compute_89,code=compute_89 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_75,code=compute_75
+NVCCFLAGS := -O3 -rdc=true -gencode=arch=compute_89,code=compute_89 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_75,code=compute_75
 LDFLAGS := -L$(CUDA_PATH)/lib64 -lcudart -Xcompiler -pthread
 
-CPU_SRC := RCKangaroo.cpp Ec.cpp utils.cpp GpuKang.cpp
+CPU_SRC := RCKangaroo.cpp Ec.cpp utils.cpp
 GPU_SRC := RCGpuCore.cu
+GPU_CPP_SRC := GpuKang.cpp
 
 CPP_OBJECTS := $(CPU_SRC:.cpp=.o)
 CU_OBJECTS := $(GPU_SRC:.cu=.o)
+GPU_CPP_OBJECTS := $(GPU_CPP_SRC:.cpp=.o)
 
 TARGET := rckangaroo
 
 all: $(TARGET) tamesgen
 
-$(TARGET): $(CPP_OBJECTS) $(CU_OBJECTS)
+$(TARGET): $(CPP_OBJECTS) $(CU_OBJECTS) $(GPU_CPP_OBJECTS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(LDFLAGS)
 
 %.o: %.cpp
@@ -25,9 +27,12 @@ $(TARGET): $(CPP_OBJECTS) $(CU_OBJECTS)
 %.o: %.cu
 	$(NVCC) $(NVCCFLAGS) -c $< -o $@
 
+GpuKang.o: GpuKang.cpp
+	$(NVCC) $(NVCCFLAGS) -c $< -o $@
+
 
 clean:
-	rm -f $(CPP_OBJECTS) $(CU_OBJECTS) tamesgen tamesgen.o
+	rm -f $(CPP_OBJECTS) $(CU_OBJECTS) $(GPU_CPP_OBJECTS) tamesgen tamesgen.o
 
 tamesgen: tamesgen.o utils.o
 	$(CC) $(CCFLAGS) -o $@ tamesgen.o utils.o


### PR DESCRIPTION
## Summary
- compile `GpuKang.cpp` with `nvcc` and enable separable compilation
- declare device constants and switch to symbol-based `cudaMemcpyToSymbol`

## Testing
- `make -j8`
- `./rckangaroo -dp 16 -range 76 -max 1 -gpu 0`


------
https://chatgpt.com/codex/tasks/task_e_689f8819d20c832ea125d5aab1fff18d