### PR TITLE
Write 22-byte GPU distances and add size checks

### DIFF
--- a/RCGpuCore.cu
+++ b/RCGpuCore.cu
@@ -556,7 +556,9 @@ __device__ __forceinline__ void BuildDP(const TKparams& Kparams, int kang_ind, u
         *(int4*)&DPs[0] = ((int4*)x_can)[0];
         *(int4*)&DPs[4] = ((int4*)x_can)[1];
         *(int4*)&DPs[8] = ((int4*)d)[0];
-        *(u64*)&DPs[12] = d[2];
+        *(u32*)&DPs[12] = (u32)d[2];
+        *(u16*)&DPs[13] = (u16)(d[2] >> 32);
+        *((u16*)&DPs[13] + 1) = 0; // zero padding to keep 22-byte distance
         DPs[14] = (k << 2) | (3 * kang_ind / Kparams.KangCnt); //kang type + phi k
 }
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -61,7 +61,6 @@ u64 GetTickCount64()
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define DB_REC_LEN			32
 #define DB_FIND_LEN			9
 #define DB_MIN_GROW_CNT		2
 
@@ -70,7 +69,8 @@ u64 GetTickCount64()
 
 #define MEM_PAGE_SIZE		(128 * 1024)
 #define RECS_IN_PAGE		(MEM_PAGE_SIZE / DB_REC_LEN)
-#define MAX_PAGES_CNT		(0xFFFFFFFF / RECS_IN_PAGE)
+#define MAX_PAGES_CNT           (0xFFFFFFFF / RECS_IN_PAGE)
+static_assert(DB_REC_LEN == 32, "DB_REC_LEN mismatch");
 
 MemPool::MemPool()
 {

--- a/utils.h
+++ b/utils.h
@@ -11,6 +11,11 @@
 #include <vector>
 #include "defs.h"
 
+#ifndef DB_REC_LEN
+#define DB_REC_LEN 32
+#endif
+static_assert(DB_REC_LEN == 32, "DB_REC_LEN must remain 32 bytes");
+
 #ifdef _WIN32
 
 	#include <Windows.h>
@@ -87,6 +92,7 @@ struct TamesHeader
         u64  rec_cnt;
 };
 #pragma pack(pop)
+static_assert(sizeof(TamesHeader) == 16, "TamesHeader size mismatch");
 
 class MemPool
 {


### PR DESCRIPTION
## Summary
- Trim GPU DP record distance field to 22 bytes to match on-disk DB record length
- Centralize DB record length definition and add static asserts for header layout
- Add compile-time check for DB record length in memory manager

## Testing
- `g++ -std=c++17 tests/test_lambda.cpp Ec.cpp utils.cpp -lpthread -I. -o test_lambda && ./test_lambda`
- `./test_lambda && echo test-passed`

------
https://chatgpt.com/codex/tasks/task_e_689fd86125c8832e9789c8f1489faddb