### PR TITLE
Ensure -base128 flag not overridden

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -892,7 +892,6 @@ int main(int argc, char* argv[])
         gRange = 0;
         gStartSet = false;
         gTamesFileName[0] = 0;
-        gTamesBase128 = false;
         gMax = 0.0;
         gGenMode = false;
         gIsOpsLimit = false;


### PR DESCRIPTION
## Summary
- Remove redundant gTamesBase128 reset so `-base128` flag controls tames format

## Testing
- `make` *(fails: boost/multiprecision/cpp_int.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ededee988832e86d5aa972773f2d7