### PR TITLE
Fix constant memory upload size for phi constants

### DIFF
--- a/GpuKang.cpp
+++ b/GpuKang.cpp
@@ -248,13 +248,15 @@ bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJump
         {
                 EcInt beta2 = g_Beta;
                 beta2.MulModP(g_Beta);
-                if ((err = cudaMemcpyToSymbol(BETA, g_Beta.data, sizeof(g_Beta.data))) != cudaSuccess)
+                // g_Beta.data has 5 limbs (40 bytes), but the GPU constant expects 4 limbs (32 bytes)
+                // copy only the lower 256 bits
+                if ((err = cudaMemcpyToSymbol(BETA, g_Beta.data, 4 * sizeof(u64))) != cudaSuccess)
                 {
                         free(jmp2_table);
                         printf("GPU %d, cudaMemcpyToSymbol BETA failed: %s\n", CudaIndex, cudaGetErrorString(err));
                         return false;
                 }
-                if ((err = cudaMemcpyToSymbol(BETA2, beta2.data, sizeof(beta2.data))) != cudaSuccess)
+                if ((err = cudaMemcpyToSymbol(BETA2, beta2.data, 4 * sizeof(u64))) != cudaSuccess)
                 {
                         free(jmp2_table);
                         printf("GPU %d, cudaMemcpyToSymbol BETA2 failed: %s\n", CudaIndex, cudaGetErrorString(err));


### PR DESCRIPTION
## Summary
- Fix cudaMemcpyToSymbol size mismatch when uploading BETA/BETA2, copying only 32 bytes (4 limbs)

## Testing
- `make`
- `g++ -O2 -I. tests/test_lambda.cpp Ec.cpp utils.cpp -o test_lambda && ./test_lambda && echo OK`
- `./rckangaroo -range 76 -dp 16 -max 1 -tames t.tmp` *(fails: No supported GPUs detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a009959e10832e9df84c3a58c2c653