### PR TITLE
Fix beta upload size for endomorphism folding

### DIFF
--- a/GpuKang.cpp
+++ b/GpuKang.cpp
@@ -248,13 +248,13 @@ bool RCGpuKang::Prepare(EcPoint _PntToSolve, int _Range, int _DP, EcJMP* _EcJump
         {
                 EcInt beta2 = g_Beta;
                 beta2.MulModP(g_Beta);
-                if ((err = cudaMemcpyToSymbol(BETA, g_Beta.data, sizeof(g_Beta.data))) != cudaSuccess)
+                if ((err = cudaMemcpyToSymbol(BETA, g_Beta.data, sizeof(u64) * 4)) != cudaSuccess)
                 {
                         free(jmp2_table);
                         printf("GPU %d, cudaMemcpyToSymbol BETA failed: %s\n", CudaIndex, cudaGetErrorString(err));
                         return false;
                 }
-                if ((err = cudaMemcpyToSymbol(BETA2, beta2.data, sizeof(beta2.data))) != cudaSuccess)
+                if ((err = cudaMemcpyToSymbol(BETA2, beta2.data, sizeof(u64) * 4)) != cudaSuccess)
                 {
                         free(jmp2_table);
                         printf("GPU %d, cudaMemcpyToSymbol BETA2 failed: %s\n", CudaIndex, cudaGetErrorString(err));

--- a/tests/test_beta.cpp
+++ b/tests/test_beta.cpp
@@ -1,0 +1,24 @@
+#include "defs.h"
+#include "Ec.h"
+#include <cassert>
+#include <boost/multiprecision/cpp_int.hpp>
+
+int main() {
+    InitEc();
+    using boost::multiprecision::cpp_int;
+
+    auto to_cpp_int = [](const EcInt& x) {
+        cpp_int r = 0;
+        for (int i = 3; i >= 0; --i) {
+            r <<= 64; r += x.data[i];
+        }
+        return r;
+    };
+
+    cpp_int beta = to_cpp_int(g_Beta);
+    cpp_int P("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F");
+    cpp_int beta3 = (beta * beta % P) * beta % P;
+    assert(beta3 == 1);
+    assert(beta != 1);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- correct `cudaMemcpyToSymbol` byte count when uploading beta and beta^2 constants
- add CPU unit test to verify beta is a non-trivial cube root of unity

## Testing
- `g++ -O3 -I/usr/local/cuda/include -I. tests/test_lambda.cpp Ec.cpp utils.cpp -o tests/test_lambda && ./tests/test_lambda`
- `g++ -O3 -I/usr/local/cuda/include -I. tests/test_beta.cpp Ec.cpp utils.cpp -o tests/test_beta && ./tests/test_beta`


------
https://chatgpt.com/codex/tasks/task_e_68a009959e10832e9df84c3a58c2c653