### PR TITLE
Handle signed GLV scalars and add regression test

### DIFF
--- a/tests/test_self_mul.cpp
+++ b/tests/test_self_mul.cpp
@@ -1,0 +1,20 @@
+#include "defs.h"
+#include "Ec.h"
+#include <cassert>
+
+bool SelfTestMul()
+{
+    EcInt k; k.RndBits(128);
+    EcPoint p_plain = Ec::MultiplyG(k);
+    EcPoint p_glv = Ec::MultiplyG_GLV(k);
+    return p_plain.IsEqual(p_glv);
+}
+
+int main()
+{
+    InitEc();
+    for (int i = 0; i < 10; ++i) {
+        assert(SelfTestMul());
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Refine GLV-based multiplication: reduce decomposition scalars to signed 128-bit values, negate points when needed and skip addition with infinity
- Add regression test exercising `SelfTestMul` to ensure GLV and plain multiplication stay in sync

## Testing
- `g++ -O3 -I. tests/test_beta.cpp Ec.cpp utils.cpp -o tests/test_beta`
- `./tests/test_beta`
- `g++ -O3 -I. tests/test_lambda.cpp Ec.cpp utils.cpp -o tests/test_lambda`
- `./tests/test_lambda`
- `g++ -O3 -I. tests/test_self_mul.cpp Ec.cpp utils.cpp -o tests/test_self_mul`
- `./tests/test_self_mul`
- `./rckangaroo --self-test-mul` *(fails: No supported GPUs detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a017a84458832e8785a13483ab2aa2