### PR TITLE
Handle zero components in GLV multiplication

### DIFF
--- a/Ec.cpp
+++ b/Ec.cpp
@@ -278,9 +278,27 @@ EcPoint Ec::MultiplyG_GLV(EcInt& k)
         EcInt k1 = from_cpp(r1);
         EcInt k2 = from_cpp(r2);
 
-        EcPoint p1 = MultiplyG(k1);
-        EcPoint p2 = MultiplyG(k2);
-        p2.x.MulModP(g_Beta);
+        bool zero1 = k1.IsZero();
+        bool zero2 = k2.IsZero();
+        if (zero1 && zero2)
+        {
+                EcPoint pnt;
+                return pnt;
+        }
+
+        EcPoint p1, p2;
+        if (!zero1)
+                p1 = MultiplyG(k1);
+        if (!zero2)
+        {
+                p2 = MultiplyG(k2);
+                p2.x.MulModP(g_Beta);
+        }
+
+        if (zero1)
+                return p2;
+        if (zero2)
+                return p1;
 
         return AddPoints(p1, p2);
 }


### PR DESCRIPTION
## Summary
- Avoid AddPoints when both GLV components are zero by early returning an empty EcPoint.
- Skip unused components and only add when both multipliers are non-zero.

## Testing
- `./rckangaroo --self-test-mul` *(fails: No supported GPUs detected)*
- `./rckangaroo --self-test-jumps` *(fails: No supported GPUs detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a062a8aaf0832e9fd0a3838f0cadf5