### PR TITLE
Add zero-scalar GLV multiplication test

### DIFF
--- a/tests/test_self_mul.cpp
+++ b/tests/test_self_mul.cpp
@@ -1,0 +1,28 @@
+#include "defs.h"
+#include "Ec.h"
+#include <cassert>
+
+int main()
+{
+    InitEc();
+
+    // baseline: compare MultiplyG and MultiplyG_GLV on a non-zero scalar
+    {
+        EcInt k; k.Set(123456789);
+        EcPoint p1 = Ec::MultiplyG(k);
+        EcPoint p2 = Ec::MultiplyG_GLV(k);
+        assert(p1.x.IsEqual(p2.x));
+        assert(p1.y.IsEqual(p2.y));
+    }
+
+    // explicit check for zero scalar
+    {
+        EcInt zero; zero.SetZero();
+        EcPoint pg = Ec::MultiplyG(zero);
+        EcPoint pglv = Ec::MultiplyG_GLV(zero);
+        assert(pg.x.IsEqual(pglv.x));
+        assert(pg.y.IsEqual(pglv.y));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add self-multiplication test verifying MultiplyG_GLV matches MultiplyG
- include explicit zero-scalar case

## Testing
- `g++ tests/test_self_mul.cpp Ec.cpp utils.cpp -std=c++17 -I. -o tests/test_self_mul && ./tests/test_self_mul`


------
https://chatgpt.com/codex/tasks/task_e_68a0b817fb64832ebd21322106a8410d