### PR TITLE
Fix sign extension for truncated distance

### DIFF
--- a/RCGpuCore.cu
+++ b/RCGpuCore.cu
@@ -555,10 +555,13 @@ __device__ __forceinline__ void BuildDP(const TKparams& Kparams, int kang_ind, u
         u32* DPs = Kparams.DPs_out + 4 + pos * GPU_DP_SIZE / 4;
         *(int4*)&DPs[0] = ((int4*)x_can)[0];
         *(int4*)&DPs[4] = ((int4*)x_can)[1];
-        *(int4*)&DPs[8] = ((int4*)d)[0];
-        *(u32*)&DPs[12] = (u32)d[2];
-        *(u16*)&DPs[13] = (u16)(d[2] >> 32);
-        *((u16*)&DPs[13] + 1) = 0; // zero padding to keep 22-byte distance
+        u8* dp8 = (u8*)DPs;
+        u8* d8 = (u8*)d;
+#pragma unroll
+        for (int i = 0; i < 22; i++)
+                dp8[32 + i] = d8[i];
+        dp8[54] = 0;
+        dp8[55] = 0;
         DPs[14] = (k << 2) | (3 * kang_ind / Kparams.KangCnt); //kang type + phi k
 }
 

--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -365,9 +365,15 @@ void CheckNewPoints()
                 if (pref_type != TAME)
                 {
                         memcpy(w.data, pref->d, sizeof(pref->d));
-                        if (pref->d[21] == 0xFF) memset(((u8*)w.data) + 22, 0xFF, 18);
+                        if (pref->d[21] == 0xFF)
+                                memset(((u8*)w.data) + 22, 0xFF, 18);
+                        else
+                                memset(((u8*)w.data) + 22, 0, 18);
                         memcpy(t.data, nrec.d, sizeof(nrec.d));
-                        if (nrec.d[21] == 0xFF) memset(((u8*)t.data) + 22, 0xFF, 18);
+                        if (nrec.d[21] == 0xFF)
+                                memset(((u8*)t.data) + 22, 0xFF, 18);
+                        else
+                                memset(((u8*)t.data) + 22, 0, 18);
                         TameType = nrec_type;
                         WildType = pref_type;
                         phi_t = nrec_k;
@@ -376,9 +382,15 @@ void CheckNewPoints()
                 else
                 {
                         memcpy(w.data, nrec.d, sizeof(nrec.d));
-                        if (nrec.d[21] == 0xFF) memset(((u8*)w.data) + 22, 0xFF, 18);
+                        if (nrec.d[21] == 0xFF)
+                                memset(((u8*)w.data) + 22, 0xFF, 18);
+                        else
+                                memset(((u8*)w.data) + 22, 0, 18);
                         memcpy(t.data, pref->d, sizeof(pref->d));
-                        if (pref->d[21] == 0xFF) memset(((u8*)t.data) + 22, 0xFF, 18);
+                        if (pref->d[21] == 0xFF)
+                                memset(((u8*)t.data) + 22, 0xFF, 18);
+                        else
+                                memset(((u8*)t.data) + 22, 0, 18);
                         TameType = TAME;
                         WildType = nrec_type;
                         phi_t = pref_k;


### PR DESCRIPTION
## Summary
- restore 0xFF sentinel-based sign extension and zero-filled tails when decoding 22-byte DP distances

## Testing
- `make clean && make`
- `./rckangaroo --self-test-mul` *(fails: No supported GPUs detected)*
- `./rckangaroo --self-test-jumps` *(fails: No supported GPUs detected)*
- `./rckangaroo --phi-fold 0 --glv-jumps 0 -range 32 -dp 18` *(fails: No supported GPUs detected)*
- `./rckangaroo --phi-fold 2 --glv-jumps 0 -range 32 -dp 18` *(fails: No supported GPUs detected)*
- `./rckangaroo --phi-fold 2 --glv-jumps 1 -range 32 -dp 18` *(fails: No supported GPUs detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a00fdfb148832e90c278e5a2381fd8