### PR TITLE
Handle zero components in GLV multiplication

### DIFF
--- a/Ec.cpp
+++ b/Ec.cpp
@@ -278,10 +278,22 @@ EcPoint Ec::MultiplyG_GLV(EcInt& k)
         EcInt k1 = from_cpp(r1);
         EcInt k2 = from_cpp(r2);
 
-        EcPoint p1 = MultiplyG(k1);
-        EcPoint p2 = MultiplyG(k2);
-        p2.x.MulModP(g_Beta);
+        bool k1_zero = k1.IsZero();
+        bool k2_zero = k2.IsZero();
 
+        EcPoint p1, p2;
+        if (!k1_zero)
+                p1 = MultiplyG(k1);
+        if (!k2_zero)
+        {
+                p2 = MultiplyG(k2);
+                p2.x.MulModP(g_Beta);
+        }
+
+        if (k1_zero)
+                return p2;
+        if (k2_zero)
+                return p1;
         return AddPoints(p1, p2);
 }
 

--- a/tests/test_glv.cpp
+++ b/tests/test_glv.cpp
@@ -1,0 +1,13 @@
+#include "Ec.h"
+#include <cassert>
+int main(){
+    Ec ec; InitEc();
+    SetRndSeed(0);
+    for(int i=0;i<100;i++){
+        EcInt k; k.RndBits(128);
+        EcPoint a = ec.MultiplyG(k);
+        EcPoint b = ec.MultiplyG_GLV(k);
+        assert(a.IsEqual(b));
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- avoid invalid point additions when GLV split produces zero scalars
- add a regression test checking GLV multiplication matches standard multiplication

## Testing
- `g++ -I. tests/test_glv.cpp Ec.cpp utils.cpp -lboost_system -lboost_thread -o tests/test_glv && ./tests/test_glv && echo glv_ok`
- `g++ -I. tests/test_beta.cpp Ec.cpp utils.cpp -lboost_system -lboost_thread -o tests/test_beta && ./tests/test_beta && echo beta_ok`
- `g++ -I. tests/test_lambda.cpp Ec.cpp utils.cpp -lboost_system -lboost_thread -o tests/test_lambda && echo lambda_ok`
- `./rckangaroo --self-test-mul` *(fails: No supported GPUs detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c734b964832e931a87b5c826c0fb