### PR TITLE
Fix sign extension for collision distance data

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -385,12 +385,13 @@ void CheckNewPoints()
                 if (pref_type != TAME)
                 {
                         memcpy(w.data, pref->d, sizeof(pref->d));
-                        if (pref->d[21] == 0xFF)
+                        // sign-extend the 22-byte distance into the full 40-byte EcInt
+                        if (pref->d[21] & 0x80)
                                 memset(((u8*)w.data) + 22, 0xFF, 18);
                         else
                                 memset(((u8*)w.data) + 22, 0, 18);
                         memcpy(t.data, nrec.d, sizeof(nrec.d));
-                        if (nrec.d[21] == 0xFF)
+                        if (nrec.d[21] & 0x80)
                                 memset(((u8*)t.data) + 22, 0xFF, 18);
                         else
                                 memset(((u8*)t.data) + 22, 0, 18);
@@ -402,12 +403,12 @@ void CheckNewPoints()
                 else
                 {
                         memcpy(w.data, nrec.d, sizeof(nrec.d));
-                        if (nrec.d[21] == 0xFF)
+                        if (nrec.d[21] & 0x80)
                                 memset(((u8*)w.data) + 22, 0xFF, 18);
                         else
                                 memset(((u8*)w.data) + 22, 0, 18);
                         memcpy(t.data, pref->d, sizeof(pref->d));
-                        if (pref->d[21] == 0xFF)
+                        if (pref->d[21] & 0x80)
                                 memset(((u8*)t.data) + 22, 0xFF, 18);
                         else
                                 memset(((u8*)t.data) + 22, 0, 18);


### PR DESCRIPTION
## Summary
- Correct collision distance reconstruction by sign-extending based on high bit rather than requiring 0xFF

## Testing
- `./rckangaroo --self-test-mul`
- `./rckangaroo --self-test-jumps`


------
https://chatgpt.com/codex/tasks/task_e_68a0fa3e6e70832ea123da469db29a96