### PR TITLE
Fix sign extension for DP records to resolve collision error

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -385,12 +385,12 @@ void CheckNewPoints()
                 if (pref_type != TAME)
                 {
                         memcpy(w.data, pref->d, sizeof(pref->d));
-                        if (pref->d[21] == 0xFF)
+                        if (pref->d[21] & 0x80)
                                 memset(((u8*)w.data) + 22, 0xFF, 18);
                         else
                                 memset(((u8*)w.data) + 22, 0, 18);
                         memcpy(t.data, nrec.d, sizeof(nrec.d));
-                        if (nrec.d[21] == 0xFF)
+                        if (nrec.d[21] & 0x80)
                                 memset(((u8*)t.data) + 22, 0xFF, 18);
                         else
                                 memset(((u8*)t.data) + 22, 0, 18);
@@ -402,12 +402,12 @@ void CheckNewPoints()
                 else
                 {
                         memcpy(w.data, nrec.d, sizeof(nrec.d));
-                        if (nrec.d[21] == 0xFF)
+                        if (nrec.d[21] & 0x80)
                                 memset(((u8*)w.data) + 22, 0xFF, 18);
                         else
                                 memset(((u8*)w.data) + 22, 0, 18);
                         memcpy(t.data, pref->d, sizeof(pref->d));
-                        if (pref->d[21] == 0xFF)
+                        if (pref->d[21] & 0x80)
                                 memset(((u8*)t.data) + 22, 0xFF, 18);
                         else
                                 memset(((u8*)t.data) + 22, 0, 18);


### PR DESCRIPTION
## Summary
- Properly sign-extend distinguished point offsets by checking the high bit instead of full-byte `0xFF`.
- Prevents incorrect negative value interpretation that led to false collision errors.

## Testing
- `make` *(fails: nvcc fatal : Unsupported gpu architecture 'compute_61')*
- `g++ -std=c++17 -O3 test_lambda.cpp Ec.cpp utils.cpp -I. -o test_lambda`
- `./test_lambda`


------
https://chatgpt.com/codex/tasks/task_e_68a0fa3e6e70832ea123da469db29a96