### PR TITLE
Handle non-matching DP collisions quietly

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -427,17 +427,14 @@ void CheckNewPoints()
                 if (delta == 1) w.MulLambdaN();
                 else if (delta == 2) w.MulLambda2N();
 
-                bool res = Collision_SOTA(gPntToSolve, t, TameType, w, WildType, false) || Collision_SOTA(gPntToSolve, t, TameType, w, WildType, true);
+                bool res = Collision_SOTA(gPntToSolve, t, TameType, w, WildType, false) ||
+                            Collision_SOTA(gPntToSolve, t, TameType, w, WildType, true);
                 if (!res)
                 {
-                        bool w12 = ((pref_type == WILD1) && (nrec_type == WILD2)) || ((pref_type == WILD2) && (nrec_type == WILD1));
-                        if (w12)
-                                ;
-                        else
-                        {
-                                printf("Collision Error\r\n");
+                        bool w12 = ((pref_type == WILD1) && (nrec_type == WILD2)) ||
+                                   ((pref_type == WILD2) && (nrec_type == WILD1));
+                        if (!w12)
                                 gTotalErrors++;
-                        }
                         continue;
                 }
                 gSolved = true;


### PR DESCRIPTION
## Summary
- avoid noisy "Collision Error" prints when DP collisions don't verify
- still track unresolved collisions via `gTotalErrors`

## Testing
- `make -j4` *(fails: unsupported gpu architecture 'compute_61', missing boost headers)*
- `./rckangaroo --self-test-mul` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fa3e6e70832ea123da469db29a96