### PR TITLE
Scale DP host buffer with GPU count

### DIFF
--- a/RCKangaroo.cpp
+++ b/RCKangaroo.cpp
@@ -41,6 +41,7 @@ CriticalSection csAddPoints;
 u8* pPntList;
 u8* pPntList2;
 volatile int PntIndex;
+int MaxCntList;
 TFastBase db;
 EcPoint gPntToSolve;
 EcInt gPrivKey;
@@ -219,13 +220,13 @@ void* kang_thr_proc(void* data)
 #endif
 void AddPointsToList(u32* data, int pnt_cnt, u64 ops_cnt)
 {
-	csAddPoints.Enter();
-	if (PntIndex + pnt_cnt >= MAX_CNT_LIST)
-	{
-		csAddPoints.Leave();
-		printf("DPs buffer overflow, some points lost, increase DP value!\r\n");
-		return;
-	}
+        csAddPoints.Enter();
+        if (PntIndex + pnt_cnt >= MaxCntList)
+        {
+                csAddPoints.Leave();
+                printf("DPs buffer overflow, some points lost, increase DP value!\r\n");
+                return;
+        }
 	memcpy(pPntList + GPU_DP_SIZE * PntIndex, data, pnt_cnt * GPU_DP_SIZE);
 	PntIndex += pnt_cnt;
 	PntTotalOps += ops_cnt;
@@ -1114,8 +1115,9 @@ int main(int argc, char* argv[])
                 return 0;
         }
 
-        cudaMallocManaged((void**)&pPntList, MAX_CNT_LIST * GPU_DP_SIZE);
-        cudaMallocManaged((void**)&pPntList2, MAX_CNT_LIST * GPU_DP_SIZE);
+        MaxCntList = MAX_DP_CNT * (GpuCnt ? GpuCnt : 1);
+        cudaMallocManaged((void**)&pPntList, (size_t)MaxCntList * GPU_DP_SIZE);
+        cudaMallocManaged((void**)&pPntList2, (size_t)MaxCntList * GPU_DP_SIZE);
         TotalOps = 0;
         TotalSolved = 0;
         gTotalErrors = 0;

--- a/defs.h
+++ b/defs.h
@@ -57,7 +57,6 @@ typedef char i8;
 
 #define DPTABLE_MAX_CNT		16
 
-#define MAX_CNT_LIST		(512 * 1024)
 
 #define DP_FLAG				0x8000
 #define INV_FLAG			0x4000


### PR DESCRIPTION
## Summary
- allocate host-side DP list based on number of GPUs
- guard DP collection against overflow using dynamic limit
- drop fixed MAX_CNT_LIST constant

## Testing
- `make tests` *(fails: nvcc fatal   : Unsupported gpu architecture 'compute_61')*


------
https://chatgpt.com/codex/tasks/task_e_68a103418cf4832ea372737c052cc2ca